### PR TITLE
Fix spanning on multi-display setups whose screens aren't aligned in a simple arrangement 

### DIFF
--- a/AerialScreenSaverExtension/AerialSaverView.swift
+++ b/AerialScreenSaverExtension/AerialSaverView.swift
@@ -451,14 +451,23 @@ final class AerialSaverView: ScreenSaverView {
         let changed = beforeID != afterID
         debugLog("🔁 [\(ptr)] windowDidChangeScreen — now id=\(afterID) zorig=\(afterOrigin) changed=\(changed)")
 
-        if changed {
-            if let layer = playerLayer {
-                CATransaction.begin()
-                CATransaction.setDisableActions(true)
-                configurePlayerLayerFrame(layer)
-                CATransaction.commit()
-            }
+        // Always reconfigure on a screen-change notification, even when
+        // `changed` is false. detectScreen() can return the same screen ID
+        // before and after the migration when both passes fell to a fallback
+        // that mis-matched the same wrong screen — gating layer
+        // reconfiguration on `changed` then prevents recovery once detection
+        // starts working (e.g. once window.screen becomes set on the new
+        // screen). The spanned-mode layer frame depends on the detected
+        // screen, so reconfiguring whenever the window's screen ownership
+        // changes is the safe thing to do.
+        if let layer = playerLayer {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            configurePlayerLayerFrame(layer)
+            CATransaction.commit()
+        }
 
+        if changed {
             // Re-resolve the per-screen overlay layout. macOS sometimes
             // moves a window to its real target screen after
             // viewDidMoveToWindow has already fired setupOverlays() —
@@ -496,12 +505,39 @@ final class AerialSaverView: ScreenSaverView {
         let winFrameDesc = self.window.map { "\($0.frame)" } ?? "nil"
         debugLog("[\(ptr)] w: \(self.window) wf:\(winFrameDesc) s:\(self.window?.screen)");
 
-        // 1. Match by the window's global midpoint. `window.frame` is in
-        //    global coordinates, so the midpoint always lands inside exactly
-        //    one screen. This is preferred over the bridge UUID below because
-        //    the bridge protocol assigns UUIDs by request order, which doesn't
-        //    necessarily match the window→screen pairing macOS chose — a
-        //    mismatch produces left/right inversion in spanned mode.
+        // 1. Match window.frame.origin to a display's CGDisplayBounds origin.
+        //    Empirically on macOS 15+ the legacyScreenSaver/AppExtension
+        //    framework positions each screensaver window at its target
+        //    display's CG top-left (top-left origin, y-down) — not the
+        //    NSScreen bottom-left origin Apple's NSWindow.frame docs
+        //    describe. So the window frame origin is a reliable per-window
+        //    identifier of the target display, even when the windows are
+        //    sized to the main display's frame (which they always are —
+        //    AerialViewController.loadView() uses NSScreen.main?.frame for
+        //    every view).
+        //
+        //    Note that this also handles a separate failure mode: window.screen
+        //    is reported as the main display for every view at initial
+        //    viewDidMoveToWindow and is nil during the
+        //    NSWindow.didChangeScreenNotification — neither point lets us
+        //    disambiguate windows by NSScreen lookup.
+        if let win = self.window {
+            let winOrigin = win.frame.origin
+            for screen in displayDetection.screens {
+                let cgOrigin = CGDisplayBounds(screen.id).origin
+                if abs(cgOrigin.x - winOrigin.x) < 0.5 && abs(cgOrigin.y - winOrigin.y) < 0.5 {
+                    foundScreen = screen
+                    displayDetection.markScreenAsUsed(id: screen.id)
+                    debugLog("📺 Screen detected via window.frame CG-origin \(winOrigin) → \(screen.description)")
+                    return
+                }
+            }
+        }
+
+        // 2. Match by the window's global midpoint. `window.frame` is in
+        //    global coordinates, so the midpoint usually lands inside
+        //    exactly one screen. Kept as a fallback for single-display
+        //    setups or arrangements where CG origins don't disambiguate.
         if let win = self.window {
             let probe = CGPoint(x: win.frame.midX, y: win.frame.midY)
             if let screen = displayDetection.findScreenContaining(globalPoint: probe) {
@@ -512,7 +548,7 @@ final class AerialSaverView: ScreenSaverView {
             }
         }
 
-        // 2. Companion-mode UUID. When the view runs under the Companion app
+        // 3. Companion-mode UUID. When the view runs under the Companion app
         //    (desktop wallpaper mode), the screen UUID is passed in at init
         //    and we can resolve it directly. This branch never fires in the
         //    extension — it only has effect when companionDisplayUUID is set.
@@ -542,13 +578,13 @@ final class AerialSaverView: ScreenSaverView {
             }
         }
 
-        // 3. Fallback: FIFO depletion by size. Helps when window.frame is
+        // 4. Fallback: FIFO depletion by size. Helps when window.frame is
         //    nil (rare) and we have no other signal.
         if let screen = displayDetection.alternateFindScreenWith(frame: self.frame) {
             foundScreen = screen
             debugLog("📺 Screen detected (FIFO fallback): \(screen.description)")
         } else if let screen = displayDetection.findScreenWith(frame: self.frame) {
-            // 4. Last-resort: exact frame match. Known-broken on multi-display
+            // 5. Last-resort: exact frame match. Known-broken on multi-display
             //    setups (matches only screens at origin (0,0)), kept solely so
             //    single-display users keep working if everything above missed.
             foundScreen = screen


### PR DESCRIPTION
 I have a crazy screen set up and the spanning display didn't detect it correctly.
This is what I wanted:

<img width="297" height="232" alt="image" src="https://github.com/user-attachments/assets/5cc1a781-3b6b-4eb3-a829-59c62d973323" />

But what the existing code did was play the same animation with different sizes and cropping on each screen.

The solution:  every AerialSaverView resolved `foundScreen` to the same screen, so every AVPlayerLayer computed an identical tRect and showed the same slice. Two issues conspired to produce that:

  1. `detectScreen()` disambiguated views primarily via the window's global midpoint match against each `NSScreen.bottomLeftFrame`. `AerialViewController.loadView()` sizes every view to `NSScreen.main.frame` (not the target screen), so on the affected setups the window covered an area that didn't land in any NSScreen rect — the midpoint match failed for every view and detection fell through to the FIFO-by-size fallback, which matched every view to the same screen.

     Empirically the legacyScreenSaver / AppExtension host positions each screensaver window so `window.frame.origin` equals `CGDisplayBounds(targetDisplay).origin` — top-left in CG coordinates, y-down, not the NSScreen bottom-left coordinate space Apple's `NSWindow.frame` documentation describes. Make that match the primary disambiguation: compare `window.frame.origin` to each screen's `CGDisplayBounds(id).origin` with a sub-pixel tolerance. The existing midpoint / Companion-UUID / FIFO / exact-frame fallbacks stay in place for single-display setups and other conventions.

     `window.screen` looked tempting but isn't useful here — it points to the main display for every view at `viewDidMoveToWindow`, and is nil during `NSWindow.didChangeScreenNotification`.

  2. `windowDidChangeScreen(_:)` gated the player-layer reconfiguration on `changed = beforeID != afterID`. When both detectScreen() passes mismatched onto the same wrong fallback screen, `changed` was false and the layer was never reconfigured even after the new detection path started returning the right screen on the migrated window. Reconfigure the layer unconditionally on the screen-change notification; the overlay-layout swap stays gated on `changed` since overlays only care when the underlying screen identity actually flips.


After correcting the code, when I ran the screensaver:

Initial detect (all three views land on the laptop):
  - View A wf=(0, 0, 1728, 1117) → [DETECT-V2] candidate id=1 cgOrigin=(0,0) dx=0 dy=0 → matches laptop. tRect = (-2042, 0, 4920, 3575).
  - View B same.
  - View C same.

  Then macOS migrates the windows, windowDidChangeScreen fires for two of them, window.screen=nil during the transition:

  View B → wf=(-2042, -2458, 1728, 1117):
  candidate id=1 cgOrigin=(0,0)         dx=2042 dy=2458
  candidate id=2 cgOrigin=(-2042,-2458) dx=0    dy=0   ← match
  Screen detected via window.frame CG-origin (-2042,-2458) → id=2 (vertical, 1080×2560)
  windowDidChangeScreen — now id=2 ... changed=true
  Spanned mode - layer frame: (0, -1015, 4920, 3575)

  View C → wf=(-962, -1600, 1728, 1117):
  candidate id=1 cgOrigin=(0,0)         dx=962  dy=1600
  candidate id=2 cgOrigin=(-2042,-2458) dx=1080 dy=858
  candidate id=4 cgOrigin=(-962,-1600)  dx=0    dy=0   ← match
  Screen detected via window.frame CG-origin (-962,-1600) → id=4 (ultrawide, 3840×1600)
  windowDidChangeScreen — now id=4 ... changed=true
  Spanned mode - layer frame: (-1080, -1117, 4920, 3575)

  View A stays on the laptop (no migration), layer frame stays (-2042, 0, 4920, 3575).

  Steady state — three distinct layer frames, one per screen:

Screen                 tRect            

Laptop (id=1)      (-2042, 0, 4920, 3575)     
Vertical (id=2)     (0, -1015, 4920, 3575)     
Ultrawide (id=4)     (-1080, -1117, 4920, 3575) 

  All three are 4920×3575 (the full spanned region) with each origin offset to put its own screen's slice inside the local view bounds. That's exactly the geometry that makes one continuous video span across all three displays.
 